### PR TITLE
Workaround snapd/AppArmor bug affecting Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PKG_ID := $(shell yq e ".id" manifest.yaml)
-PKG_VERSION := $(shell yq e ".version" manifest.yaml)
+PKG_ID := $(shell yq e ".id" < manifest.yaml)
+PKG_VERSION := $(shell yq e ".version" < manifest.yaml)
 TS_FILES := $(shell find ./ -name \*.ts)
 HELLO_WORLD_SRC := $(shell find ./hello-world/src) hello-world/Cargo.toml hello-world/Cargo.lock
 


### PR DESCRIPTION
I installed yq on my Pop OS computer through Snap, but I think I ran into [this snapd/AppArmor bug](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1849753), because I was getting "permission denied" errors when running the yq commands in the Makefile here.  (Got the same errors running the commands myself in a shell too.)

This commit works around the issue by passing the `manifest.yaml` content to yq via. a shell redirect rather than passing the filename to yq and letting it read the file contents.

(I know this bug isn't the fault of StartOS, but I figure this workaround could help anyone else using Pop OS to get up and running that much faster.)

See also: https://stackoverflow.com/a/76002505/2747593