### PR TITLE
chore: support git worktrees in s9pk.mk

### DIFF
--- a/s9pk.mk
+++ b/s9pk.mk
@@ -3,6 +3,10 @@
 
 PACKAGE_ID := $(shell awk -F"'" '/id:/ {print $$2}' startos/manifest/index.ts)
 INGREDIENTS := $(shell start-cli s9pk list-ingredients 2>/dev/null)
+# Resolve the actual git dir so this works inside git worktrees, where .git
+# is a file pointing at <main>/.git/worktrees/<name> rather than a directory.
+GIT_DIR := $(shell git rev-parse --git-dir 2>/dev/null)
+GIT_DEPS := $(if $(GIT_DIR),$(GIT_DIR)/HEAD $(GIT_DIR)/index)
 ARCHES ?= x86 arm riscv
 TARGETS ?= arches
 ifdef VARIANT
@@ -50,12 +54,12 @@ x86 x86_64: arch/x86_64
 arm arm64 aarch64: arch/aarch64
 riscv riscv64: arch/riscv64
 
-$(BASE_NAME).s9pk: $(INGREDIENTS) .git/HEAD .git/index
+$(BASE_NAME).s9pk: $(INGREDIENTS) $(GIT_DEPS)
 	@$(MAKE) --no-print-directory ingredients
 	@echo "   Packing '$@'..."
 	start-cli s9pk pack -o $@
 
-$(BASE_NAME)_%.s9pk: $(INGREDIENTS) .git/HEAD .git/index
+$(BASE_NAME)_%.s9pk: $(INGREDIENTS) $(GIT_DEPS)
 	@$(MAKE) --no-print-directory ingredients
 	@echo "   Packing '$@'..."
 	start-cli s9pk pack --arch=$* -o $@


### PR DESCRIPTION
In a git worktree, `.git` is a file pointing at `<main>/.git/worktrees/<name>` rather than a directory, so the hardcoded `.git/HEAD` and `.git/index` prerequisites don't exist and make fails with:

```
make: *** No rule to make target '.git/HEAD'.  Stop.
```

Resolve the real git dir at make-time via `git rev-parse --git-dir` and use `$(GIT_DIR)/HEAD` / `$(GIT_DIR)/index` instead. Falls back gracefully if not in a git checkout (e.g. tarball builds) — the prerequisite simply becomes empty.

Verified `make` proceeds past dependency resolution in a worktree checkout.

Note: `s9pk.mk` is marked DO NOT EDIT in CLAUDE.md — happy to route this through wherever the canonical copy lives instead if preferred.