### PR TITLE
ci: skip release when package id is 'hello-world'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,20 @@ on:
       - 'v*.*'
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      id: ${{ steps.read.outputs.id }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          id="$(awk -F"'" '/id:/ {print $2; exit}' startos/manifest/index.ts)"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
   release:
+    needs: guard
+    if: needs.guard.outputs.id != 'hello-world'
     uses: start9labs/shared-workflows/.github/workflows/release.yml@master
     with:
       # FREE_DISK_SPACE: true

--- a/.github/workflows/tagAndRelease.yml
+++ b/.github/workflows/tagAndRelease.yml
@@ -10,7 +10,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      id: ${{ steps.read.outputs.id }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          id="$(awk -F"'" '/id:/ {print $2; exit}' startos/manifest/index.ts)"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
   tag:
+    needs: guard
+    if: needs.guard.outputs.id != 'hello-world'
     uses: start9labs/shared-workflows/.github/workflows/tagAndRelease.yml@master
     with:
       REFERENCE_REGISTRY: ${{ vars.REFERENCE_REGISTRY }}


### PR DESCRIPTION
## Summary

- This repo is a reference template that gets forked to start new packages. The canonical `hello-world-startos` itself should never publish to the registry — it's reference-only.
- Add a tiny `guard` job to `release.yml` and `tagAndRelease.yml` that reads the package id from `startos/manifest/index.ts` (same `awk -F"'" '/id:/ {print $2}'` recipe `s9pk.mk` uses) and gates the publish job with `if: needs.guard.outputs.id != 'hello-world'`.
- Forks rename the manifest id, so they release normally. The canonical repo never does.
- `build.yml` is intentionally untouched so PR builds in this repo still verify.

## Test plan

- [ ] Merge → confirm `Tag and Release` workflow run on master shows the `guard` job succeeded and the `tag` job was skipped (due to the `if:`).
- [ ] Verify no new tag is created and no release is published.
- [ ] Sanity-check on a fork (e.g. the upcoming `helix-home-startos`): after renaming the id, confirm `tagAndRelease` proceeds and a release is produced.