### PR TITLE
s9pk.mk: expose TARGETS via 'make print-TARGETS' for matrix builds

### DIFF
--- a/s9pk.mk
+++ b/s9pk.mk
@@ -8,7 +8,10 @@ INGREDIENTS := $(shell start-cli s9pk list-ingredients 2>/dev/null)
 GIT_DIR := $(shell git rev-parse --git-dir 2>/dev/null)
 GIT_DEPS := $(if $(GIT_DIR),$(GIT_DIR)/HEAD $(GIT_DIR)/index)
 ARCHES ?= x86 arm riscv
-TARGETS ?= arches
+# TARGETS is the list of leaf make-targets the build matrix fans out over.
+# Defaults to the arches; variant packages override (e.g. immich, ollama, vllm
+# set this to a list of variant or variant-arch leaf targets).
+TARGETS ?= $(ARCHES)
 ifdef VARIANT
 BASE_NAME := $(PACKAGE_ID)_$(VARIANT)
 else
@@ -43,6 +46,12 @@ endef
 all: $(TARGETS)
 
 arches: $(ARCHES)
+
+# Generic make-variable introspection. Used by the release workflow to
+# read $(TARGETS) and fan out one matrix runner per target. `make -s
+# print-TARGETS` echoes the list with no other output.
+print-%:
+	@echo '$($*)'
 
 universal: $(BASE_NAME).s9pk
 	$(call SUMMARY,$<)


### PR DESCRIPTION
## What

Two minimal plumbing changes to `s9pk.mk` so the shared release workflow
can introspect each package's build matrix:

1. **Default `TARGETS` to `$(ARCHES)`** instead of the indirection
   target `arches`. Plain `make` behavior is unchanged — `all:
   $(TARGETS)` still expands to the arches list — but
   `make -s print-TARGETS` now returns the actual leaves (e.g.
   `x86 arm riscv`) instead of just `arches`. Variant packages
   that already override `TARGETS` to a list (`immich`, `ollama`,
   `vllm`) are unaffected.

2. **Add a generic `print-%` rule** — the standard make-variable
   introspection pattern. Works for any variable, not just
   `TARGETS`.

## Why

Companion to [Start9Labs/shared-workflows#5][workflow-pr], which
restructures `release.yml` to fan out builds across parallel matrix
runners. The workflow runs `make -s print-TARGETS` in each package's
checkout and uses the output as the matrix. If the target doesn't
exist (i.e. the package hasn't yet re-synced `s9pk.mk`), the workflow
falls back to a single-entry matrix that runs plain `make` — same
wall time as today plus a small artifact handoff cost. So the
rollout is lazy: packages get arch-level parallelism on the release
after they sync `s9pk.mk`, with no atomic flag day.

## Per-package impact after re-sync

- **Plain packages** — get arch-level parallel builds for free
  (`make print-TARGETS` returns `x86 arm riscv` or whatever the
  package overrides `ARCHES` to).
- **Variant packages** (`immich`, `ollama`, `vllm`) — get
  variant-level parallel builds from their existing `TARGETS`
  override. For leaf-level (variant × arch) parallelism they can
  refactor their `Makefile` to enumerate per-variant-per-arch leaf
  targets, but that's optional.

## Smoke test

```
$ make -s print-TARGETS
x86 arm
$ make -s print-ARCHES
x86 arm
$ make -s print-PACKAGE_ID
hello-world
```

[workflow-pr]: https://github.com/Start9Labs/shared-workflows/pull/5
