### PR TITLE
fix: install deps with npm ci only; drop lockfile-regen rule

### DIFF
--- a/s9pk.mk
+++ b/s9pk.mk
@@ -130,11 +130,8 @@ javascript/index.js: $(shell find startos -type f) tsconfig.json node_modules
 	npm run check
 	npm run build
 
-node_modules: package-lock.json
+node_modules: package-lock.json package.json
 	npm ci
-
-package-lock.json: package.json
-	npm i
 
 clean:
 	@echo "Cleaning up build artifacts..."


### PR DESCRIPTION
The `package-lock.json: package.json` rule in `s9pk.mk` ran `npm i`, which **rewrites the tracked lockfile**. `make` decides whether to run it by comparing mtimes, and git does not preserve mtimes on checkout, so on a fresh CI clone the rule fired *spuriously* (no dependency actually changed) and could leave the working tree dirty — producing a manifest `gitHash` with a `-modified` suffix.

When a multi-arch build hit this on only some arches (an mtime coin-flip, decided independently per runner), those arches' manifests diverged from the clean ones, and the registry rejected the publish:

```
package.add: package metadata mismatch: remove the existing version first, then re-add
```

(Observed on a recent `bitcoin-knots #knots:29.3:10` release — riscv64 came out `-modified` while x86_64/aarch64 were clean.)

## Fix

`npm ci` already populated `node_modules` from the committed lock and **never mutates a tracked file**. Collapse the two rules into one:

```diff
-node_modules: package-lock.json
-	npm ci
-
-package-lock.json: package.json
-	npm i
+node_modules: package-lock.json package.json
+	npm ci
```

## Why nothing breaks

- The install is identical — `npm ci` was already the command building `node_modules` from the committed `package-lock.json`. Same deps, same bundle, same s9pk, minus the spurious `-modified`.
- Nothing else consumed the deleted rule; `package-lock.json` was only a prerequisite of `node_modules` and is a committed source file.
- Adding `package.json` as a prerequisite makes `npm ci` re-validate sync whenever either file changes, failing loudly (and safely — no tracked-file writes) if they drift.

## Behavioral change (intended)

Hand-editing `package.json` and running `make` no longer auto-regenerates the lock; `npm ci` fails with "not in sync" instead. Updating dependencies is now an explicit `npm install` + commit of both files — which is the correct, reviewable workflow for a reproducible build.

This is the canonical `s9pk.mk`; once merged it should propagate to the fleet's vendored copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)