### PR TITLE
chore: use start-cli s9pk select for make install

### DIFF
--- a/s9pk.mk
+++ b/s9pk.mk
@@ -82,11 +82,11 @@ install: | check-deps check-init
 		echo "Error: You must define \"host: http://server-name.local\" in ~/.startos/config.yaml"; \
 		exit 1; \
 	fi; \
-	S9PK=$$(ls -t *.s9pk 2>/dev/null | head -1); \
-	if [ -z "$$S9PK" ]; then \
+	if [ -z "$$(ls *.s9pk 2>/dev/null)" ]; then \
 		echo "Error: No .s9pk file found. Run 'make' first."; \
 		exit 1; \
 	fi; \
+	S9PK=$$(start-cli s9pk select *.s9pk) || exit 1; \
 	printf "\n🚀 Installing %s to %s ...\n" "$$S9PK" "$$HOST"; \
 	start-cli package install -s "$$S9PK"
 

--- a/s9pk.mk
+++ b/s9pk.mk
@@ -86,7 +86,7 @@ install: | check-deps check-init
 		echo "Error: No .s9pk file found. Run 'make' first."; \
 		exit 1; \
 	fi; \
-	S9PK=$$(start-cli s9pk select *.s9pk) || exit 1; \
+	S9PK=$$(start-cli s9pk select) || exit 1; \
 	printf "\n🚀 Installing %s to %s ...\n" "$$S9PK" "$$HOST"; \
 	start-cli package install -s "$$S9PK"
 


### PR DESCRIPTION
`make install` previously picked the most recently built `.s9pk` (`ls -t *.s9pk | head -1`). For multi-arch builds that's just whichever file was packed last — not necessarily one the target server can run.

This switches selection to `start-cli s9pk select *.s9pk`, which queries the target server's `server.device-info` and returns the best **compatible** s9pk (filtered by OS-version compat range and hardware/arch requirements, ranked by specificity). The host is already required and validated earlier in the target, so no new precondition.

The "no .s9pk found" guard is kept (and reworded to a plain `ls` existence check) so the friendly "Run 'make' first" message still fires before `select` runs.